### PR TITLE
[BUGFIX] Save log message as is without calling strip_tags

### DIFF
--- a/Classes/Utility/Logger.php
+++ b/Classes/Utility/Logger.php
@@ -123,7 +123,7 @@ class Logger implements SingletonInterface
         $this->counter++;
         $entry->setCrdate(time());
         $entry->setMessage(
-                strip_tags($logData['msg'])
+                $logData['msg']
         );
         $entry->setExtkey(
                 strip_tags($logData['extKey'])


### PR DESCRIPTION
With calling strip_tags log messages which accidentally contained
"<" and ">" (e.g. in a formula) had been saved incomplete.

Resolves #4