### PR TITLE
fix: backend module does not show any entry

### DIFF
--- a/Classes/Domain/Repository/EntryRepository.php
+++ b/Classes/Domain/Repository/EntryRepository.php
@@ -427,8 +427,12 @@ class EntryRepository implements SingletonInterface
                 if ($entries[$i]['extra_data'] === '') {
                     $extraData = '';
                 } else {
-                    $extraData = gzuncompress($entries[$i]['extra_data']);
-                    $extraData = htmlspecialchars(var_export(unserialize($extraData), true));
+                    try {
+                        $extraData = gzuncompress($entries[$i]['extra_data']);
+                        $extraData = htmlspecialchars(var_export(unserialize($extraData), true));
+                    } catch (\Exception $e) {
+                        $extraData = $e->getMessage();
+                    }
                 }
                 $entries[$i]['extra_data'] = $extraData;
             }


### PR DESCRIPTION
Im some cases gzuncompress() throws an error in EntryRepository on line 430 (e.g. in some ext:tika logs) and from that time no entry will be shown in the backend module.